### PR TITLE
Lock down support-v4 to 26.0.+

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -8,7 +8,7 @@ repositories{
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:26.+'
+    compile 'com.android.support:support-v4:26.0.+'
     compile(name:'barcodescanner', ext:'aar')
 }
 


### PR DESCRIPTION
This fixes following bug on our BF:
> Could not find com.android.support:support-core-ui:26.1.0.